### PR TITLE
updated v0.2 YAML in autosplit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,12 +115,6 @@
                   </suiteXmlFiles>
                   <reuseForks>true</reuseForks>
                   <forkCount>1</forkCount>
-                  <properties>
-                    <property>
-                      <name>testnames</name>
-                      <value>${selectedTests}</value>
-                    </property>
-                  </properties>
                 </configuration>
             </plugin>
             <plugin>

--- a/yaml/linux/testng_hyperexecute_autosplit_sample.yaml
+++ b/yaml/linux/testng_hyperexecute_autosplit_sample.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1
+version: 0.2
 globalTimeout: 150
 testSuiteTimeout: 150
 testSuiteStep: 150
@@ -12,6 +12,7 @@ retryOnFailure: true
 maxRetries: 1
 concurrency: 4
 
+
 shell: bash
 
 env:
@@ -23,31 +24,29 @@ cacheDirectories:
   - .m2
 
 pre:
-  # Download and install packages in the CACHE_DIR.
   # Skip execution of the tests in the pre step
   - mvn -Dmaven.repo.local=./.m2 dependency:resolve
 
 post:
-  - cat yaml/linux/testng_hyperexecute_autosplit_sample.yaml
+  - ls target/surefire-reports/
 
 mergeArtifacts: true
+
 
 uploadArtefacts:
  - name: ExecutionSnapshots
    path:
     - target/surefire-reports/html/**
-
 report: true
 partialReports:
   location: target/surefire-reports/html
   type: html
   frameworkName: extent
 
-testDiscovery:
-  type: raw
-  mode: dynamic
-  command: grep 'test name' xml/testng_linux.xml | awk '{print$2}' | sed 's/name=//g' | sed 's/>//g'
-
-testRunnerCommand: mvn test -Dplatname=linux -Dmaven.repo.local=./.m2 dependency:resolve -DselectedTests=$test
+framework:
+  name: maven/testng
+  defaultReports: false
+  flags:
+    - "-Dplatname=linux"
 
 jobLabel: [selenium-testng, linux, autosplit]

--- a/yaml/mac/testng_hyperexecute_autosplit_sample.yaml
+++ b/yaml/mac/testng_hyperexecute_autosplit_sample.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1
+version: 0.2
 globalTimeout: 150
 testSuiteTimeout: 150
 testSuiteStep: 150
@@ -11,9 +11,7 @@ retryOnFailure: true
 
 maxRetries: 1
 concurrency: 4
-
 shell: bash
-
 env:
   # PAT: ${{ .secrets.testKey }}
   CACHE_DIR: m2_cache_dir
@@ -23,14 +21,14 @@ cacheDirectories:
   - .m2
 
 pre:
-  # Download and install packages in the CACHE_DIR.
   # Skip execution of the tests in the pre step
   - mvn -Dmaven.repo.local=./.m2 dependency:resolve
 
 post:
-  - cat yaml/mac/testng_hyperexecute_autosplit_sample.yaml
+  - ls target/surefire-reports/
 
 mergeArtifacts: true
+
 
 uploadArtefacts:
  - name: ExecutionSnapshots
@@ -43,11 +41,10 @@ partialReports:
   type: html
   frameworkName: extent
 
-testDiscovery:
-  type: raw
-  mode: dynamic
-  command: grep 'test name' xml/testng_mac.xml | awk '{print$2}' | sed 's/name=//g' | sed 's/>//g'
-
-testRunnerCommand: mvn test -Dplatname=mac -Dmaven.repo.local=./.m2 dependency:resolve -DselectedTests=$test
+framework:
+  name: maven/testng
+  defaultReports: false
+  flags:
+    - "-Dplatname=mac"
 
 jobLabel: [selenium-testng, mac, autosplit]

--- a/yaml/win/testng_hyperexecute_autosplit_sample.yaml
+++ b/yaml/win/testng_hyperexecute_autosplit_sample.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.1
+version: 0.2
 globalTimeout: 150
 testSuiteTimeout: 150
 testSuiteStep: 150
@@ -21,29 +21,30 @@ cacheDirectories:
   - .m2
 
 pre:
-  # Download and install packages in the CACHE_DIR.
   # Skip execution of the tests in the pre step
   - mvn -Dmaven.repo.local=./.m2 dependency:resolve
 
 post:
-  - cat yaml/win/testng_hyperexecute_autosplit_sample.yaml
+  - ls target/surefire-reports/
 
 mergeArtifacts: true
+
+
 uploadArtefacts:
  - name: ExecutionSnapshots
    path:
     - target/surefire-reports/html/**
+
 report: true
 partialReports:
   location: target/surefire-reports/html
   type: html
-  frameworkName: extent    
+  frameworkName: extent
 
-testDiscovery:
-  type: raw
-  mode: dynamic
-  command: grep 'test name' xml/testng_win.xml | awk '{print$2}' | sed 's/name=//g' | sed 's/\x3e//g'
-
-testRunnerCommand: mvn test `-Dplatname=win `-Dmaven.repo.local=./.m2 dependency:resolve `-DselectedTests=$test
+framework:
+  name: maven/testng
+  defaultReports: false
+  flags:
+    - "-Dplatname=win"
 
 jobLabel: [selenium-testng, win, autosplit]


### PR DESCRIPTION
1. Added the functionality for Yaml 0.2 in the auto-split file for linux, mac and windows.
2. Updated the pom.xml file -> removed the "testname" property