### PR TITLE
feat: add OCP pre-prod YAML with onpremEnv: ocp-pre-prod

### DIFF
--- a/yaml/linux/v1/testng_hyperexecute_matrix_sample_ocp.yaml
+++ b/yaml/linux/v1/testng_hyperexecute_matrix_sample_ocp.yaml
@@ -1,0 +1,32 @@
+---
+version: 0.1
+runson: ${matrix.os}
+
+onpremEnv: ocp-pre-prod
+
+matrix:
+  tests: ["Test_1"]
+  browser: ["Chrome"]
+  version: ["latest"]
+  os: ["linux"]
+
+runtime:
+  language: java
+  version: 11
+
+cacheKey: '{{ checksum "pom.xml" }}'
+cacheDirectories:
+  - .m2
+
+pre:
+  - mvn -Dmaven.repo.local=./.m2 dependency:resolve
+
+testSuites:
+  - mvn test -Dplatname=linux -Dmaven.repo.local=./.m2 -DselectedTests=$tests
+
+parallelism: 1
+
+retryOnFailure: true
+maxRetries: 1
+
+jobLabel: [selenium-testng, linux, matrix, ocp-pre-prod]


### PR DESCRIPTION
Copy of testng_hyperexecute_matrix_sample.yaml with onpremEnv: ocp-pre-prod added for OCP infra job routing. Used by LTQAAutomation OCP test scenarios.