### PR TITLE
fix: update Test2/3/4 to React selectors for sample-todo-app

### DIFF
--- a/src/test/java/Test1.java
+++ b/src/test/java/Test1.java
@@ -139,7 +139,7 @@ public class Test1 {
             String actualText = driver.findElement(remainingItem).getText();
             String expectedText = remaining + " of " + totalCount + " remaining";
 
-            if (!actualText.contains(expectedText)) {
+            if (!actualText.toLowerCase().contains(expectedText.toLowerCase())) {
                 test1.log(Status.FAIL, "Wrong Text Description");
                 System.out.println("unmatched at " + expectedText + " " + actualText);
                 status = "failed";
@@ -196,7 +196,7 @@ public class Test1 {
             String actualText = driver.findElement(remainingItem).getText();
             String expectedText = remaining + " of " + totalCount + " remaining";
 
-            if (!actualText.contains(expectedText)) {
+            if (!actualText.toLowerCase().contains(expectedText.toLowerCase())) {
                 test2.log(Status.FAIL, "Wrong Text Description");
                 System.out.println("unmatched at " + expectedText + " " + actualText);
                 status = "failed";

--- a/src/test/java/Test2.java
+++ b/src/test/java/Test2.java
@@ -127,11 +127,11 @@ public class Test2 {
             driver.findElement(By.xpath(xpath)).click();
             Thread.sleep(500);
             test1.log(Status.PASS, "Item No. " + i + " marked completed");
-            By remainingItem = By.className("ng-binding");
+            By remainingItem = By.cssSelector("[data-testid='remaining-count']");
             String actualText = driver.findElement(remainingItem).getText();
-            String expectedText = remaining + " of " + totalCount + " tasks remaining";
+            String expectedText = remaining + " of " + totalCount + " remaining";
 
-            if (!actualText.contains(expectedText)) {
+            if (!actualText.toLowerCase().contains(expectedText.toLowerCase())) {
                 test1.log(Status.FAIL, "Wrong Text Description");
                 System.out.println("unmatched at " + expectedText + " " + actualText);
                 status = "failed";

--- a/src/test/java/Test3.java
+++ b/src/test/java/Test3.java
@@ -129,11 +129,11 @@ public class Test3 {
             driver.findElement(By.xpath(xpath)).click();
             Thread.sleep(500);
             test1.log(Status.PASS, "Item No. " + i + " marked completed");
-            By remainingItem = By.className("ng-binding");
+            By remainingItem = By.cssSelector("[data-testid='remaining-count']");
             String actualText = driver.findElement(remainingItem).getText();
-            String expectedText = remaining + " of " + totalCount + " tasks remaining";
+            String expectedText = remaining + " of " + totalCount + " remaining";
 
-            if (!actualText.contains(expectedText)) {
+            if (!actualText.toLowerCase().contains(expectedText.toLowerCase())) {
                 test1.log(Status.FAIL, "Wrong Text Description");
                 System.out.println("unmatched at " + expectedText + " " + actualText);
                 status = "failed";

--- a/src/test/java/Test4.java
+++ b/src/test/java/Test4.java
@@ -129,11 +129,11 @@ public class Test4 {
             driver.findElement(By.xpath(xpath)).click();
             Thread.sleep(500);
             test1.log(Status.PASS, "Item No. " + i + " marked completed");
-            By remainingItem = By.className("ng-binding");
+            By remainingItem = By.cssSelector("[data-testid='remaining-count']");
             String actualText = driver.findElement(remainingItem).getText();
-            String expectedText = remaining + " of " + totalCount + " tasks remaining";
+            String expectedText = remaining + " of " + totalCount + " remaining";
 
-            if (!actualText.contains(expectedText)) {
+            if (!actualText.toLowerCase().contains(expectedText.toLowerCase())) {
                 test1.log(Status.FAIL, "Wrong Text Description");
                 System.out.println("unmatched at " + expectedText + " " + actualText);
                 status = "failed";


### PR DESCRIPTION
## Summary
- `sample-todo-app` was migrated AngularJS → React, but only `Test1` was updated. `Test2`/`Test3`/`Test4` still used the AngularJS `By.className("ng-binding")` locator, which no longer exists in the React DOM.
- The stale locator threw `NoSuchElementException`, failing those HyperExecute tasks (and their retries) while `Test1` passed. Because the exception fired before `tearDown()` could flip `lambda-status`, the LambdaTest session showed "passed" while HyperExecute reported the task as failed.
- This aligns Test2/3/4 with Test1: locator → `By.cssSelector("[data-testid='remaining-count']")`, expected text drops "tasks" (`"<n> of <total> remaining"`), and the assertion is now case-insensitive.

## Test plan
- [ ] Run the autosplit job: `./hyperexecute --config yaml/linux/v1/testng_hyperexecute_autosplit_sample.yaml --env stage`
- [ ] Confirm all 4 tasks (Test_1–Test_4) pass without retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)