### PR TITLE
fix(localdriver): React sample-todo-app URL + selector update

### DIFF
--- a/src/test/java/Test1.java
+++ b/src/test/java/Test1.java
@@ -50,7 +50,7 @@ public class Test1
     public static String username = System.getenv("LT_USERNAME");
     public static String access_key = System.getenv("LT_ACCESS_KEY");
 
-    String testURL = "https://lambdatest.github.io/sample-todo-app/";
+    String testURL = "https://ltqa-frontend.lambdatestinternal.com/sample-todo-app/";
     String testURLTitle = "Sample page - lambdatest.com";
     @BeforeMethod
     public void testSetUp() throws Exception
@@ -103,11 +103,11 @@ public class Test1
             driver.findElement(By.xpath(xpath)).click();
             Thread.sleep(500);
             test1.log(LogStatus.PASS, "Item No. " + i + " marked completed");
-            By remainingItem = By.className("ng-binding");
+            By remainingItem = By.cssSelector("[data-testid='remaining-count']");
             String actualText = driver.findElement(remainingItem).getText();
-            String expectedText = remaining+" of "+totalCount+" tasks remaining";
+            String expectedText = remaining+" of "+totalCount+" remaining";
 
-            if (!actualText.contains(expectedText)) {
+            if (!actualText.toLowerCase().contains(expectedText.toLowerCase())) {
                 test1.log(LogStatus.FAIL, "Wrong Text Description");
                 status = "failed";
             }


### PR DESCRIPTION
## Summary
The `sample-todo-app` migrated to React. The `localdriver` branch's `Test1.java` still used the old github.io URL and an AngularJS-era selector (`ng-binding`), so the **GitHub App Integration trigger-API job** — which runs against this `localdriver` branch — fails at the test level, even though `main` already passes (it received the React fix in #58).

## Changes (`src/test/java/Test1.java`)
- `testURL` → `https://ltqa-frontend.lambdatestinternal.com/sample-todo-app/`
- remaining-count locator: `By.className("ng-binding")` → `By.cssSelector("[data-testid='remaining-count']")`
- expected text: drop `"tasks"` (`"X of Y remaining"`) and compare case-insensitively

The local `ChromeDriver` setup is intentionally left unchanged — that's the purpose of this branch (mirrors `main`'s selector fix only, not its RemoteWebDriver setup).

## Test plan
- [ ] Re-run `@hypertest_github_app_integration_api_testing` (LTQAAutomation) on stage — the trigger-API job on `localdriver` should now reach `completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)