### PR TITLE
fix(tests): make remaining-count check pass on current sample-todo-app

### DIFF
--- a/src/test/java/Test1.java
+++ b/src/test/java/Test1.java
@@ -139,7 +139,7 @@ public class Test1 {
             String actualText = driver.findElement(remainingItem).getText();
             String expectedText = remaining + " of " + totalCount + " remaining";
 
-            if (!actualText.contains(expectedText)) {
+            if (!actualText.toLowerCase().contains(expectedText.toLowerCase())) {
                 test1.log(Status.FAIL, "Wrong Text Description");
                 System.out.println("unmatched at " + expectedText + " " + actualText);
                 status = "failed";
@@ -196,7 +196,7 @@ public class Test1 {
             String actualText = driver.findElement(remainingItem).getText();
             String expectedText = remaining + " of " + totalCount + " remaining";
 
-            if (!actualText.contains(expectedText)) {
+            if (!actualText.toLowerCase().contains(expectedText.toLowerCase())) {
                 test2.log(Status.FAIL, "Wrong Text Description");
                 System.out.println("unmatched at " + expectedText + " " + actualText);
                 status = "failed";

--- a/src/test/java/Test2.java
+++ b/src/test/java/Test2.java
@@ -127,11 +127,11 @@ public class Test2 {
             driver.findElement(By.xpath(xpath)).click();
             Thread.sleep(500);
             test1.log(Status.PASS, "Item No. " + i + " marked completed");
-            By remainingItem = By.className("ng-binding");
+            By remainingItem = By.cssSelector("[data-testid='remaining-count']");
             String actualText = driver.findElement(remainingItem).getText();
-            String expectedText = remaining + " of " + totalCount + " tasks remaining";
+            String expectedText = remaining + " of " + totalCount + " remaining";
 
-            if (!actualText.contains(expectedText)) {
+            if (!actualText.toLowerCase().contains(expectedText.toLowerCase())) {
                 test1.log(Status.FAIL, "Wrong Text Description");
                 System.out.println("unmatched at " + expectedText + " " + actualText);
                 status = "failed";

--- a/src/test/java/Test3.java
+++ b/src/test/java/Test3.java
@@ -129,11 +129,11 @@ public class Test3 {
             driver.findElement(By.xpath(xpath)).click();
             Thread.sleep(500);
             test1.log(Status.PASS, "Item No. " + i + " marked completed");
-            By remainingItem = By.className("ng-binding");
+            By remainingItem = By.cssSelector("[data-testid='remaining-count']");
             String actualText = driver.findElement(remainingItem).getText();
-            String expectedText = remaining + " of " + totalCount + " tasks remaining";
+            String expectedText = remaining + " of " + totalCount + " remaining";
 
-            if (!actualText.contains(expectedText)) {
+            if (!actualText.toLowerCase().contains(expectedText.toLowerCase())) {
                 test1.log(Status.FAIL, "Wrong Text Description");
                 System.out.println("unmatched at " + expectedText + " " + actualText);
                 status = "failed";

--- a/src/test/java/Test4.java
+++ b/src/test/java/Test4.java
@@ -129,11 +129,11 @@ public class Test4 {
             driver.findElement(By.xpath(xpath)).click();
             Thread.sleep(500);
             test1.log(Status.PASS, "Item No. " + i + " marked completed");
-            By remainingItem = By.className("ng-binding");
+            By remainingItem = By.cssSelector("[data-testid='remaining-count']");
             String actualText = driver.findElement(remainingItem).getText();
-            String expectedText = remaining + " of " + totalCount + " tasks remaining";
+            String expectedText = remaining + " of " + totalCount + " remaining";
 
-            if (!actualText.contains(expectedText)) {
+            if (!actualText.toLowerCase().contains(expectedText.toLowerCase())) {
                 test1.log(Status.FAIL, "Wrong Text Description");
                 System.out.println("unmatched at " + expectedText + " " + actualText);
                 status = "failed";


### PR DESCRIPTION
## Problem
On HyperExecute, matrix jobs using these tests are marked **failed** (*"Job failed as encountered a Test level failure"*) even though maven reports `BUILD SUCCESS` (`Tests run: 2, Failures: 0`).

## Root cause
The remaining-count element renders **uppercase** (`"9 OF 10 REMAINING"`), and Selenium `getText()` returns the rendered (uppercased) text. The tests compared it against a **lowercase** expected string using case-sensitive `String.contains()`, so the check never matched:

```java
String actualText = driver.findElement(remainingItem).getText();      // "9 OF 10 REMAINING"
String expectedText = remaining + " of " + totalCount + " remaining";  // "9 of 10 remaining"
if (!actualText.contains(expectedText)) {                              // case-sensitive → always true
    status = "failed";                                                 // pushed via lambda-status in tearDown()
}
```

The methods only `log(Status.FAIL,...)` and set a string — they never assert/throw — so TestNG/maven pass, but `tearDown()` sends `lambda-status=failed`, so HyperExecute marks the session (and the job) failed. That's the "passes locally, fails on HyperExecute" contradiction.

## Fix
- **All four:** compare case-insensitively — `actualText.toLowerCase().contains(expectedText.toLowerCase())`.
- **Test2/3/4:** drop the extra word `tasks` from `expectedText` (the app text has no "tasks"), and switch the stale `By.className("ng-binding")` locator to the app's actual `[data-testid='remaining-count']` element — the same selector `Test1` already uses successfully.

`mvn test-compile` → BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)