### PR TITLE
Update Linux autosplit discovery mode and simplify hybrid Maven pre-step

### DIFF
--- a/yaml/linux/v1/testng_hyperexecute_autosplit_sample.yaml
+++ b/yaml/linux/v1/testng_hyperexecute_autosplit_sample.yaml
@@ -18,7 +18,7 @@ pre:
 
 testDiscovery:
   type: raw
-  mode: static
+  mode: dynamic
   command: grep 'test name' xml/testng_linux.xml | awk '{print$2}' | sed 's/name=//g' | sed 's/>//g'
 
 testRunnerCommand: mvn test -Dplatname=linux -Dmaven.repo.local=./.m2 dependency:resolve -DselectedTests=$test

--- a/yaml/testng_hyperexecute_hybrid_sample.yaml
+++ b/yaml/testng_hyperexecute_hybrid_sample.yaml
@@ -35,7 +35,7 @@ testDiscovery:
       grep 'test name' xml/testng_linux.xml | awk '{print$2}' | sed 's/name=//g' | sed 's/\x3e//g'
 
 pre:
-  - mvn -Dmaven.repo.local=./.m2 dependency:resolve
+  - mvn dependency:resolve
 
 linuxTestRunnerCommand: mvn test -Dplatname=linux -Dmaven.repo.local=./.m2 dependency:resolve -DselectedTests=$test
 winTestRunnerCommand: mvn test `-Dplatname=win `-Dmaven.repo.local=./.m2 dependency:resolve `-DselectedTests=$test


### PR DESCRIPTION
## Summary

This PR updates the HyperExecute sample YAML configuration by:

- Updating the Linux v1 autosplit discovery mode.
- Simplifying the Maven dependency resolution command in the hybrid sample.

## Motivation

While validating the HyperExecute sample configurations, these changes simplified the sample configuration and aligned it with the verified execution flow.

## Testing

- Verified the updated YAML configuration locally.
- Verified HyperExecute execution after the configuration changes.