### PR TITLE
Upgrade to Selenium 4.39.0 and Java 17 (localdriver)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
 <version>1.0-SNAPSHOT</version>
 
 <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
 </properties>
 
 <dependencies>
@@ -28,17 +28,17 @@
     <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-java</artifactId>
-        <version>3.141.59</version>
+        <version>4.39.0</version>
     </dependency>
     <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-remote-driver</artifactId>
-        <version>3.141.59</version>
+        <version>4.39.0</version>
     </dependency>
     <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-chrome-driver</artifactId>
-        <version>3.141.59</version>
+        <version>4.39.0</version>
     </dependency>
     <dependency>
         <groupId>junit</groupId>
@@ -82,8 +82,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/Test1.java
+++ b/src/test/java/Test1.java
@@ -57,7 +57,7 @@ public class Test1
     {
         driver = new ChromeDriver();
         driver.manage().window().maximize();
-        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
 
         System.out.println("Started session");
     }
@@ -74,7 +74,7 @@ public class Test1
       //  Thread.sleep(8*60*1000);
         //add
         /* Selenium Java 3.141.59 */
-        WebDriverWait wait = new WebDriverWait(driver, 5);
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(5));
         /* WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10)); */
         test1.log(LogStatus.PASS, "Wait created");
         /* Click on the Link */


### PR DESCRIPTION
### What
Upgrades this sample (localdriver branch) to build and run on **Java 17** with **Selenium 4.39.0**.

**pom.xml**
- `selenium-java`, `selenium-remote-driver`, `selenium-chrome-driver`: `3.141.59` → `4.39.0`
- `maven.compiler.source/target`: `1.8` → `17`

**Test1.java** — Selenium 4 timeout API migration:
- `implicitlyWait(10, TimeUnit.SECONDS)` → `implicitlyWait(Duration.ofSeconds(10))`
- `new WebDriverWait(driver, 5)` → `new WebDriverWait(driver, Duration.ofSeconds(5))`

### Why
On-prem / enterprise HyperExecute runners (e.g. Wells Fargo) are Java-17-only. Selenium 3.141.59 + source `1.8` is unsupported/fragile on Java 17 (byte-buddy / illegal reflective access), especially with the local ChromeDriver used here.

### Verification
`mvn -DskipTests test-compile` → **BUILD SUCCESS** on OpenJDK 17.0.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)